### PR TITLE
⚡ Bolt: Optimize useVisemeManager idle state

### DIFF
--- a/src/components/Character/hooks/__tests__/useVisemeManager.perf.test.tsx
+++ b/src/components/Character/hooks/__tests__/useVisemeManager.perf.test.tsx
@@ -1,0 +1,109 @@
+import { renderHook } from '@testing-library/react';
+import { useVisemeManager } from '../useVisemeManager';
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as THREE from 'three';
+import type { RootState } from '@react-three/fiber';
+// Mock useFrame
+let frameCallback: ((state: RootState, delta: number) => void) | null = null;
+vi.mock('@react-three/fiber', () => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  useFrame: (cb: any) => {
+    frameCallback = cb;
+  },
+}));
+
+// Mock useChatbot store
+const mockChatbotState = {
+    isAudioPlaying: false,
+    lipsyncManager: null,
+    webrtcLipsyncManager: null,
+    audioPlayer: null,
+    audioSourceType: 'file',
+    isAgentSpeaking: false,
+};
+
+vi.mock('../../../hooks/useChatbot', () => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  useChatbot: (selector: any) => selector(mockChatbotState),
+}));
+
+// Mock VISEME_VALUES to have a small known set
+vi.mock('../../../../utils/webrtcLipsync', () => ({
+  VISEME_VALUES: ['viseme1', 'viseme2'],
+}));
+
+describe('useVisemeManager Performance', () => {
+  beforeEach(() => {
+    frameCallback = null;
+    vi.clearAllMocks();
+    mockChatbotState.isAudioPlaying = false;
+    mockChatbotState.isAgentSpeaking = false;
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('stops reading morph targets when idle and settled', () => {
+    // Setup mock mesh with proxy to count reads/writes
+    // Start with values that need to settle to 0
+    const morphTargetInfluences = [0.1, 0.1];
+    let writeCount = 0;
+    let readCount = 0;
+
+    const proxyInfluences = new Proxy(morphTargetInfluences, {
+      set: (target, prop, value) => {
+        if (!isNaN(Number(prop))) {
+          writeCount++;
+        }
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (target as any)[prop] = value;
+        return true;
+      },
+      get: (target, prop) => {
+        if (!isNaN(Number(prop))) {
+            readCount++;
+        }
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        return (target as any)[prop];
+      }
+    });
+
+    const mesh = {
+      morphTargetDictionary: { 'viseme1': 0, 'viseme2': 1 },
+      morphTargetInfluences: proxyInfluences,
+    } as unknown as THREE.SkinnedMesh;
+
+    renderHook(() => useVisemeManager({ avatarSkinnedMeshes: [mesh] }));
+
+    expect(frameCallback).toBeDefined();
+    if (!frameCallback) return;
+
+    // Run frames until it settles
+    // It should settle quickly
+    for (let i = 0; i < 50; i++) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        frameCallback({} as any, 0.016);
+    }
+
+    const initialReadCount = readCount;
+    const initialWriteCount = writeCount;
+
+    // Check if it settled (values should be close to 0)
+    expect(morphTargetInfluences[0]).toBeLessThan(0.001);
+    expect(morphTargetInfluences[1]).toBeLessThan(0.001);
+
+    // Run more frames.
+    // Without optimization, it will continue to READ values to check if update is needed
+    // With optimization, it should stop reading entirely
+    for (let i = 0; i < 50; i++) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        frameCallback({} as any, 0.016);
+    }
+
+    // If optimized, readCount should match initialReadCount (no new reads)
+    // If unoptimized, it will increase by (2 visemes * 50 frames) = 100 reads
+    expect(readCount).toBe(initialReadCount);
+    expect(writeCount).toBe(initialWriteCount);
+  });
+});

--- a/src/components/Character/hooks/useVisemeManager.ts
+++ b/src/components/Character/hooks/useVisemeManager.ts
@@ -12,9 +12,6 @@ import { ANIMATION_CONSTANTS } from '../../../config/animations';
 import type { SkinnedMeshArray, AudioSourceType, LipsyncManager, WebRTCLipsyncManager } from '../../../types';
 import type { SkinnedMesh } from 'three';
 
-// Optimization: Extract viseme values to constant to avoid per-frame allocation
-const VISEME_VALUES = Object.values(VISEMES);
-
 interface UseVisemeManagerParams {
   avatarSkinnedMeshes: SkinnedMeshArray;
 }
@@ -40,6 +37,9 @@ export const useVisemeManager = ({ avatarSkinnedMeshes }: UseVisemeManagerParams
   const audioPlayerRef = useRef(audioPlayer);
   const audioSourceTypeRef = useRef<AudioSourceType>(audioSourceType);
   const isAgentSpeakingRef = useRef(isAgentSpeaking);
+
+  // Optimization: Track if visemes are fully reset to skip unnecessary updates
+  const visemesSettled = useRef<boolean>(false);
 
   // Update refs when values change
   useEffect(() => {
@@ -75,11 +75,14 @@ export const useVisemeManager = ({ avatarSkinnedMeshes }: UseVisemeManagerParams
 
   /**
    * Update a morph target value with smoothing
+   * Returns true if all targets are settled (reached target value)
    */
   const updateMorphTarget = useCallback(
-    (target: string, targetValue: number): void => {
+    (target: string, targetValue: number): boolean => {
       const targets = morphTargetCache[target];
-      if (!targets) return;
+      if (!targets) return true;
+
+      let isSettled = true;
 
       for (let i = 0; i < targets.length; i++) {
         const { mesh, index } = targets[i];
@@ -104,8 +107,10 @@ export const useVisemeManager = ({ avatarSkinnedMeshes }: UseVisemeManagerParams
               : ANIMATION_CONSTANTS.VISEME_DEACTIVATION_SMOOTHING;
 
           mesh.morphTargetInfluences[index] = MathUtils.lerp(currentValue, targetValue, smoothing);
+          isSettled = false;
         }
       }
+      return isSettled;
     },
     [morphTargetCache]
   );
@@ -152,15 +157,27 @@ export const useVisemeManager = ({ avatarSkinnedMeshes }: UseVisemeManagerParams
         }
       }
 
+      // If playing, we are definitely not settled
+      visemesSettled.current = false;
+
       VISEME_VALUES.forEach((viseme) => {
         const targetValue = viseme === currentViseme ? 1 : 0;
         updateMorphTarget(viseme, targetValue);
       });
     } else {
+      // Optimization: Skip unnecessary updates if visemes are already fully reset
+      if (visemesSettled.current) return;
+
+      let allSettled = true;
       // Reset all visemes when not playing
       VISEME_VALUES.forEach((viseme) => {
-        updateMorphTarget(viseme, 0);
+        const settled = updateMorphTarget(viseme, 0);
+        if (!settled) allSettled = false;
       });
+
+      if (allSettled) {
+        visemesSettled.current = true;
+      }
     }
   });
 };


### PR DESCRIPTION
⚡ Bolt: Optimize useVisemeManager idle state

💡 What: Optimized `useVisemeManager` to skip processing in `useFrame` when the character is not speaking and viseme morph targets are fully reset. Also fixed a bug where `VISEME_VALUES` was being redeclared incorrectly.

🎯 Why: The previous implementation iterated through all visemes every frame even when idle, causing unnecessary CPU usage and Three.js overhead.

📊 Impact: Eliminates ~15-20 morph target updates and lookups per frame when the character is idle.

🔬 Measurement: Added `src/components/Character/hooks/__tests__/useVisemeManager.perf.test.tsx` which verifies that property reads on `morphTargetInfluences` stop completely when the animation is settled.

---
*PR created automatically by Jules for task [7456762231977056886](https://jules.google.com/task/7456762231977056886) started by @santosflores*