### PR TITLE
⚡ Bolt: Optimize useVisemeManager idle performance

### DIFF
--- a/src/components/Character/hooks/__tests__/useVisemeManager.perf.test.tsx
+++ b/src/components/Character/hooks/__tests__/useVisemeManager.perf.test.tsx
@@ -1,0 +1,109 @@
+import { renderHook } from '@testing-library/react';
+import { useVisemeManager } from '../useVisemeManager';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import * as THREE from 'three';
+import type { RootState } from '@react-three/fiber';
+import { VISEME_VALUES } from '../../../../utils/webrtcLipsync';
+
+// Mock useFrame
+let frameCallback: ((state: RootState, delta: number) => void) | null = null;
+vi.mock('@react-three/fiber', () => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  useFrame: (cb: any) => {
+    frameCallback = cb;
+  },
+}));
+
+// Mock useChatbot
+const mockUseChatbot = vi.fn();
+vi.mock('../../../../hooks/useChatbot', () => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  useChatbot: (selector: any) => mockUseChatbot(selector),
+}));
+
+describe('useVisemeManager Performance', () => {
+  beforeEach(() => {
+    frameCallback = null;
+    vi.clearAllMocks();
+  });
+
+  it('stops reading morphTargetInfluences when settled', () => {
+    // Setup state
+    const state = {
+      lipsyncManager: null,
+      webrtcLipsyncManager: null,
+      isAudioPlaying: false,
+      audioPlayer: null,
+      audioSourceType: null,
+      isAgentSpeaking: false,
+    };
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    mockUseChatbot.mockImplementation((selector: any) => selector(state));
+
+    // Setup mesh with proxy
+    let readCount = 0;
+    const morphTargetInfluences = [0.1]; // Start non-zero
+
+    // Use Proxy to count reads
+    const proxyInfluences = new Proxy(morphTargetInfluences, {
+      get: (target, prop) => {
+        // Only count numeric index access
+        if (typeof prop === 'string' && !isNaN(Number(prop))) {
+          readCount++;
+        }
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        return (target as any)[prop];
+      },
+      set: (target, prop, value) => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (target as any)[prop] = value;
+        return true;
+      }
+    });
+
+    // Ensure we have a valid key for the dictionary
+    const firstViseme = VISEME_VALUES[0];
+    const dictionary: Record<string, number> = {};
+    dictionary[firstViseme] = 0;
+
+    const mesh = {
+      morphTargetDictionary: dictionary,
+      morphTargetInfluences: proxyInfluences,
+    } as unknown as THREE.SkinnedMesh;
+
+    renderHook(() => useVisemeManager({ avatarSkinnedMeshes: [mesh] }));
+
+    expect(frameCallback).toBeDefined();
+    if (!frameCallback) return;
+
+    // Run frames to settle
+    const initialReadCount = readCount;
+
+    // Run 50 frames. It should settle.
+    for (let i = 0; i < 50; i++) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        frameCallback({} as any, 0.016);
+    }
+
+    const settledReadCount = readCount;
+
+    // Debug info
+    if (settledReadCount === initialReadCount) {
+        console.log('VISEME_VALUES:', VISEME_VALUES);
+        console.log('Mesh Dictionary:', mesh.morphTargetDictionary);
+    }
+
+    expect(settledReadCount).toBeGreaterThan(initialReadCount);
+
+    // Run 50 MORE frames.
+    // OPTIMIZED: readCount should NOT increase
+
+    for (let i = 0; i < 50; i++) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        frameCallback({} as any, 0.016);
+    }
+
+    expect(readCount).toBe(settledReadCount);
+  });
+});

--- a/src/components/Character/hooks/useVisemeManager.ts
+++ b/src/components/Character/hooks/useVisemeManager.ts
@@ -12,9 +12,6 @@ import { ANIMATION_CONSTANTS } from '../../../config/animations';
 import type { SkinnedMeshArray, AudioSourceType, LipsyncManager, WebRTCLipsyncManager } from '../../../types';
 import type { SkinnedMesh } from 'three';
 
-// Optimization: Extract viseme values to constant to avoid per-frame allocation
-const VISEME_VALUES = Object.values(VISEMES);
-
 interface UseVisemeManagerParams {
   avatarSkinnedMeshes: SkinnedMeshArray;
 }
@@ -41,6 +38,9 @@ export const useVisemeManager = ({ avatarSkinnedMeshes }: UseVisemeManagerParams
   const audioSourceTypeRef = useRef<AudioSourceType>(audioSourceType);
   const isAgentSpeakingRef = useRef(isAgentSpeaking);
 
+  // Optimization: Track if visemes are settled (all zero) to skip processing
+  const visemesSettledRef = useRef(false);
+
   // Update refs when values change
   useEffect(() => {
     lipsyncManagerRef.current = lipsyncManager;
@@ -50,6 +50,11 @@ export const useVisemeManager = ({ avatarSkinnedMeshes }: UseVisemeManagerParams
     audioSourceTypeRef.current = audioSourceType;
     isAgentSpeakingRef.current = isAgentSpeaking;
   }, [lipsyncManager, webrtcLipsyncManager, isAudioPlaying, audioPlayer, audioSourceType, isAgentSpeaking]);
+
+  // Reset settled state when meshes change to ensure we clear any existing values
+  useEffect(() => {
+    visemesSettledRef.current = false;
+  }, [avatarSkinnedMeshes]);
 
   /**
    * Optimization: Cache the mapping from viseme name to morph target indices for each mesh.
@@ -136,6 +141,8 @@ export const useVisemeManager = ({ avatarSkinnedMeshes }: UseVisemeManagerParams
         currentIsAgentSpeaking; // Only lipsync when agent is speaking
 
     if (isPlaying && currentIsAudioPlaying && currentLipsyncManager) {
+      visemesSettledRef.current = false; // Active, so not settled
+
       currentLipsyncManager.processAudio();
       const currentViseme = currentLipsyncManager.viseme;
 
@@ -157,10 +164,29 @@ export const useVisemeManager = ({ avatarSkinnedMeshes }: UseVisemeManagerParams
         updateMorphTarget(viseme, targetValue);
       });
     } else {
-      // Reset all visemes when not playing
+      // Optimization: Skip processing if already settled
+      if (visemesSettledRef.current) return;
+
+      let allSettled = true;
       VISEME_VALUES.forEach((viseme) => {
         updateMorphTarget(viseme, 0);
+
+        // Check if this viseme is effectively zero for all affected meshes
+        // This validation ensures we truly stop when all targets are settled
+        const targets = morphTargetCache[viseme];
+        if (targets) {
+          for (let i = 0; i < targets.length; i++) {
+             const { mesh, index } = targets[i];
+             if (mesh.morphTargetInfluences && mesh.morphTargetInfluences[index] > 0.001) {
+               allSettled = false;
+             }
+          }
+        }
       });
+
+      if (allSettled) {
+        visemesSettledRef.current = true;
+      }
     }
   });
 };


### PR DESCRIPTION
⚡ Bolt: Optimized `useVisemeManager` for idle performance.

💡 What: Implemented a "settled" state check in the `useVisemeManager` hook. When audio is not playing, the hook now verifies if all viseme morph targets have reached zero (idle state). Once settled, it skips the `useFrame` loop entirely until audio plays again or the mesh changes. Also fixed a critical bug where `VISEME_VALUES` was redeclared incorrectly, causing a potential crash.

🎯 Why: The previous implementation iterated over all visemes and updated morph targets every frame (60fps), even when the character was silent and the mouth was closed. This consumed unnecessary CPU cycles on the main thread.

📊 Impact: Reduces `useFrame` overhead for lip sync to near zero when the character is not speaking.
🔬 Measurement: Added `useVisemeManager.perf.test.tsx` which verifies that `morphTargetInfluences` are no longer accessed after the animation settles.

---
*PR created automatically by Jules for task [13912921853407333087](https://jules.google.com/task/13912921853407333087) started by @santosflores*