### PR TITLE
⚡ Bolt: Optimize useVisemeManager idle state

### DIFF
--- a/src/components/Character/hooks/useVisemeManager.perf.test.ts
+++ b/src/components/Character/hooks/useVisemeManager.perf.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useVisemeManager } from './useVisemeManager';
+
+// Mock dependencies
+vi.mock('@react-three/fiber', () => ({
+  useFrame: vi.fn((callback) => {
+    // Expose the callback for manual invocation
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (globalThis as any).__useFrameCallback = callback;
+  }),
+}));
+
+vi.mock('../../../hooks/useChatbot', () => ({
+  useChatbot: vi.fn(),
+}));
+
+// Mock VISEME_VALUES to have a controlled list
+vi.mock('../../../utils/webrtcLipsync', () => ({
+  VISEME_VALUES: ['viseme_aa', 'viseme_E', 'viseme_I'], // subset for testing
+}));
+
+// Mock ANIMATION_CONSTANTS
+vi.mock('../../../config/animations', () => ({
+  ANIMATION_CONSTANTS: {
+    VISEME_ACTIVATION_SMOOTHING: 0.1,
+    VISEME_DEACTIVATION_SMOOTHING: 0.1,
+  },
+}));
+
+import { useChatbot } from '../../../hooks/useChatbot';
+
+describe('useVisemeManager Performance', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let mockMesh: any;
+  let accessCount: number;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    accessCount = 0;
+
+    // Create a mesh with proxied morphTargetInfluences
+    const realInfluences = [0, 0, 0];
+    const proxyInfluences = new Proxy(realInfluences, {
+      get(target, prop, receiver) {
+        if (typeof prop !== 'symbol' && !isNaN(Number(prop))) {
+          accessCount++;
+        }
+        return Reflect.get(target, prop, receiver);
+      },
+      set(target, prop, value, receiver) {
+        return Reflect.set(target, prop, value, receiver);
+      },
+    });
+
+    mockMesh = {
+      morphTargetDictionary: {
+        'viseme_aa': 0,
+        'viseme_E': 1,
+        'viseme_I': 2,
+      },
+      morphTargetInfluences: proxyInfluences,
+    };
+
+    // Default mock state
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (useChatbot as any).mockImplementation((selector: any) => {
+      const state = {
+        lipsyncManager: null,
+        webrtcLipsyncManager: null,
+        isAudioPlaying: false,
+        audioPlayer: null,
+        audioSourceType: null,
+        isAgentSpeaking: false,
+      };
+      return selector(state);
+    });
+  });
+
+  afterEach(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    delete (globalThis as any).__useFrameCallback;
+  });
+
+  it('reduces morphTargetInfluences access when idle (optimized)', () => {
+    renderHook(() => useVisemeManager({ avatarSkinnedMeshes: [mockMesh] }));
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const frameCallback = (globalThis as any).__useFrameCallback;
+    expect(frameCallback).toBeDefined();
+
+    // Run frame loop 10 times
+    for (let i = 0; i < 10; i++) {
+      frameCallback();
+    }
+
+    console.log(`Optimized Access Count: ${accessCount}`);
+
+    // With optimization:
+    // Frame 1: Checks all 3 visemes. Each has 2 accesses (typeof check + value read). Total 6.
+    // Frame 1: All settle. `visemesSettledRef` becomes true.
+    // Frame 2-10: Short-circuits. 0 accesses.
+    // Total should be exactly 6.
+
+    expect(accessCount).toBeLessThanOrEqual(10);
+    expect(accessCount).toBe(6);
+  });
+});

--- a/src/components/Character/hooks/useVisemeManager.ts
+++ b/src/components/Character/hooks/useVisemeManager.ts
@@ -12,9 +12,6 @@ import { ANIMATION_CONSTANTS } from '../../../config/animations';
 import type { SkinnedMeshArray, AudioSourceType, LipsyncManager, WebRTCLipsyncManager } from '../../../types';
 import type { SkinnedMesh } from 'three';
 
-// Optimization: Extract viseme values to constant to avoid per-frame allocation
-const VISEME_VALUES = Object.values(VISEMES);
-
 interface UseVisemeManagerParams {
   avatarSkinnedMeshes: SkinnedMeshArray;
 }
@@ -41,6 +38,9 @@ export const useVisemeManager = ({ avatarSkinnedMeshes }: UseVisemeManagerParams
   const audioSourceTypeRef = useRef<AudioSourceType>(audioSourceType);
   const isAgentSpeakingRef = useRef(isAgentSpeaking);
 
+  // Optimization: Track if visemes are fully reset to 0 to skip updates in idle loop
+  const visemesSettledRef = useRef(false);
+
   // Update refs when values change
   useEffect(() => {
     lipsyncManagerRef.current = lipsyncManager;
@@ -50,6 +50,11 @@ export const useVisemeManager = ({ avatarSkinnedMeshes }: UseVisemeManagerParams
     audioSourceTypeRef.current = audioSourceType;
     isAgentSpeakingRef.current = isAgentSpeaking;
   }, [lipsyncManager, webrtcLipsyncManager, isAudioPlaying, audioPlayer, audioSourceType, isAgentSpeaking]);
+
+  // Reset settled state when meshes change to ensure we verify their state
+  useEffect(() => {
+    visemesSettledRef.current = false;
+  }, [avatarSkinnedMeshes]);
 
   /**
    * Optimization: Cache the mapping from viseme name to morph target indices for each mesh.
@@ -75,11 +80,14 @@ export const useVisemeManager = ({ avatarSkinnedMeshes }: UseVisemeManagerParams
 
   /**
    * Update a morph target value with smoothing
+   * Returns true if all meshes for this target are settled (at target value)
    */
   const updateMorphTarget = useCallback(
-    (target: string, targetValue: number): void => {
+    (target: string, targetValue: number): boolean => {
       const targets = morphTargetCache[target];
-      if (!targets) return;
+      if (!targets) return true;
+
+      let allSettled = true;
 
       for (let i = 0; i < targets.length; i++) {
         const { mesh, index } = targets[i];
@@ -104,8 +112,10 @@ export const useVisemeManager = ({ avatarSkinnedMeshes }: UseVisemeManagerParams
               : ANIMATION_CONSTANTS.VISEME_DEACTIVATION_SMOOTHING;
 
           mesh.morphTargetInfluences[index] = MathUtils.lerp(currentValue, targetValue, smoothing);
+          allSettled = false;
         }
       }
+      return allSettled;
     },
     [morphTargetCache]
   );
@@ -136,6 +146,9 @@ export const useVisemeManager = ({ avatarSkinnedMeshes }: UseVisemeManagerParams
         currentIsAgentSpeaking; // Only lipsync when agent is speaking
 
     if (isPlaying && currentIsAudioPlaying && currentLipsyncManager) {
+      // Optimization: Reset settled state as we are now playing
+      visemesSettledRef.current = false;
+
       currentLipsyncManager.processAudio();
       const currentViseme = currentLipsyncManager.viseme;
 
@@ -157,10 +170,20 @@ export const useVisemeManager = ({ avatarSkinnedMeshes }: UseVisemeManagerParams
         updateMorphTarget(viseme, targetValue);
       });
     } else {
+      // Optimization: Short-circuit if already settled (all visemes at 0)
+      if (visemesSettledRef.current) return;
+
+      let allSettled = true;
+
       // Reset all visemes when not playing
       VISEME_VALUES.forEach((viseme) => {
-        updateMorphTarget(viseme, 0);
+        const settled = updateMorphTarget(viseme, 0);
+        if (!settled) allSettled = false;
       });
+
+      if (allSettled) {
+        visemesSettledRef.current = true;
+      }
     }
   });
 };


### PR DESCRIPTION
💡 **What**: Introduced a `visemesSettledRef` to short-circuit the `useFrame` loop in `useVisemeManager` when the character is not speaking and all morph targets have reset to 0.

🎯 **Why**: The previous implementation iterated over all 21 visemes and checked morph target values every frame (60fps), even when the character was idle/silent. This wasted CPU cycles on redundant checks.

📊 **Impact**: Reduces `morphTargetInfluences` accesses by ~90% during idle states (confirmed by benchmark dropping from 60 to 6 accesses in a 10-frame window).

🔬 **Measurement**: Verified with the new performance test `src/components/Character/hooks/useVisemeManager.perf.test.ts` which counts proxy accesses to the mesh properties.

Also fixed a latent runtime bug in `useVisemeManager.ts` where `VISEMES` was referenced but not imported.

---
*PR created automatically by Jules for task [8101422352972772017](https://jules.google.com/task/8101422352972772017) started by @santosflores*