### PR TITLE
⚡ Bolt: Optimize useVisemeManager idle state

### DIFF
--- a/src/components/Character/hooks/__tests__/useVisemeManager.test.tsx
+++ b/src/components/Character/hooks/__tests__/useVisemeManager.test.tsx
@@ -1,0 +1,131 @@
+import { renderHook } from "@testing-library/react";
+import { useVisemeManager } from "../useVisemeManager";
+import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
+import type { RootState } from "@react-three/fiber";
+import type { SkinnedMesh } from "three";
+
+// Mock useFrame
+let frameCallback: ((state: RootState, delta: number) => void) | null = null;
+vi.mock("@react-three/fiber", () => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  useFrame: (cb: any) => {
+    frameCallback = cb;
+  },
+}));
+
+// Mock useChatbot
+vi.mock("../../../../hooks/useChatbot", () => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  useChatbot: (selector: any) => {
+    // Mock state
+    const state = {
+      lipsyncManager: null,
+      webrtcLipsyncManager: null,
+      isAudioPlaying: false,
+      audioPlayer: null,
+      audioSourceType: "file",
+      isAgentSpeaking: false,
+    };
+    return selector(state);
+  },
+}));
+
+// Mock webrtcLipsync to avoid import issues and provide VISEMES
+vi.mock("../../../../utils/webrtcLipsync", () => ({
+  VISEMES: {
+    aa: "aa",
+    E: "E",
+    I: "I",
+    O: "O",
+    U: "U",
+    sil: "sil",
+  },
+  VISEME_VALUES: ["aa", "E", "I", "O", "U", "sil"],
+}));
+
+describe("useVisemeManager Performance", () => {
+  beforeEach(() => {
+    frameCallback = null;
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("stops reading morph targets when visemes are settled to zero", () => {
+    // Setup mock mesh with proxy to count reads and writes
+    let readCount = 0;
+    let writeCount = 0;
+
+    // Start with 'aa' viseme active (0.5)
+    const morphTargetInfluences = [0.5, 0, 0, 0, 0, 0];
+    const morphTargetDictionary = {
+      aa: 0,
+      E: 1,
+      I: 2,
+      O: 3,
+      U: 4,
+      sil: 5,
+    };
+
+    const proxyInfluences = new Proxy(morphTargetInfluences, {
+      get: (target, prop) => {
+        if (!isNaN(Number(prop))) {
+          readCount++;
+        }
+        return target[Number(prop)];
+      },
+      set: (target, prop, value) => {
+        if (!isNaN(Number(prop))) {
+          writeCount++;
+        }
+        target[Number(prop)] = value;
+        return true;
+      },
+    });
+
+    const mesh = {
+      morphTargetDictionary,
+      morphTargetInfluences: proxyInfluences,
+    } as unknown as SkinnedMesh;
+
+    renderHook(() => useVisemeManager({ avatarSkinnedMeshes: [mesh] }));
+
+    expect(frameCallback).toBeDefined();
+    if (!frameCallback) return;
+
+    // Run frames to let it settle (reset to 0)
+    // Smoothing is involved, so it might take a few frames.
+    // We want to verify that eventually, READS stop.
+
+    // First 50 frames: should see reads and writes as it resets
+    for (let i = 0; i < 50; i++) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      frameCallback({} as any, 0.016);
+    }
+
+    // Check that we had activity
+    expect(readCount).toBeGreaterThan(0);
+    expect(writeCount).toBeGreaterThan(0);
+
+    // Reset counters
+    const readsAfterSettle = readCount;
+    const writesAfterSettle = writeCount;
+
+    // Run more frames.
+    // WITHOUT optimization: Reads will continue (checking if reset is needed).
+    // WITH optimization: Reads should stop (short-circuited).
+    for (let i = 0; i < 50; i++) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      frameCallback({} as any, 0.016);
+    }
+
+    // This assertion expects the optimization to be present.
+    // It will FAIL currently.
+    expect(readCount).toBe(readsAfterSettle);
+
+    // Writes should also have stopped (this should pass even without optimization if logic is correct)
+    expect(writeCount).toBe(writesAfterSettle);
+  });
+});

--- a/src/components/Character/hooks/useVisemeManager.ts
+++ b/src/components/Character/hooks/useVisemeManager.ts
@@ -3,17 +3,19 @@
  * Handles mouth morph targets based on audio playback (file or WebRTC)
  */
 
-import { useCallback, useRef, useEffect, useMemo } from 'react';
-import { useFrame } from '@react-three/fiber';
-import { MathUtils } from 'three';
-import { VISEME_VALUES } from '../../../utils/webrtcLipsync';
-import { useChatbot } from '../../../hooks/useChatbot';
-import { ANIMATION_CONSTANTS } from '../../../config/animations';
-import type { SkinnedMeshArray, AudioSourceType, LipsyncManager, WebRTCLipsyncManager } from '../../../types';
-import type { SkinnedMesh } from 'three';
-
-// Optimization: Extract viseme values to constant to avoid per-frame allocation
-const VISEME_VALUES = Object.values(VISEMES);
+import { useCallback, useRef, useEffect, useMemo } from "react";
+import { useFrame } from "@react-three/fiber";
+import { MathUtils } from "three";
+import { VISEME_VALUES } from "../../../utils/webrtcLipsync";
+import { useChatbot } from "../../../hooks/useChatbot";
+import { ANIMATION_CONSTANTS } from "../../../config/animations";
+import type {
+  SkinnedMeshArray,
+  AudioSourceType,
+  LipsyncManager,
+  WebRTCLipsyncManager,
+} from "../../../types";
+import type { SkinnedMesh } from "three";
 
 interface UseVisemeManagerParams {
   avatarSkinnedMeshes: SkinnedMeshArray;
@@ -24,10 +26,14 @@ interface UseVisemeManagerParams {
  * Supports both file-based audio and WebRTC audio streams
  * @param avatarSkinnedMeshes - Array of skinned meshes with morph targets
  */
-export const useVisemeManager = ({ avatarSkinnedMeshes }: UseVisemeManagerParams): void => {
+export const useVisemeManager = ({
+  avatarSkinnedMeshes,
+}: UseVisemeManagerParams): void => {
   // Use proper hook selectors at component level instead of getState() in useFrame
   const lipsyncManager = useChatbot((state) => state.lipsyncManager);
-  const webrtcLipsyncManager = useChatbot((state) => state.webrtcLipsyncManager);
+  const webrtcLipsyncManager = useChatbot(
+    (state) => state.webrtcLipsyncManager,
+  );
   const isAudioPlaying = useChatbot((state) => state.isAudioPlaying);
   const audioPlayer = useChatbot((state) => state.audioPlayer);
   const audioSourceType = useChatbot((state) => state.audioSourceType);
@@ -35,7 +41,9 @@ export const useVisemeManager = ({ avatarSkinnedMeshes }: UseVisemeManagerParams
 
   // Use refs to track values for useFrame (avoid accessing store in render loop)
   const lipsyncManagerRef = useRef<LipsyncManager | null>(lipsyncManager);
-  const webrtcLipsyncManagerRef = useRef<WebRTCLipsyncManager | null>(webrtcLipsyncManager);
+  const webrtcLipsyncManagerRef = useRef<WebRTCLipsyncManager | null>(
+    webrtcLipsyncManager,
+  );
   const isAudioPlayingRef = useRef(isAudioPlaying);
   const audioPlayerRef = useRef(audioPlayer);
   const audioSourceTypeRef = useRef<AudioSourceType>(audioSourceType);
@@ -49,19 +57,32 @@ export const useVisemeManager = ({ avatarSkinnedMeshes }: UseVisemeManagerParams
     audioPlayerRef.current = audioPlayer;
     audioSourceTypeRef.current = audioSourceType;
     isAgentSpeakingRef.current = isAgentSpeaking;
-  }, [lipsyncManager, webrtcLipsyncManager, isAudioPlaying, audioPlayer, audioSourceType, isAgentSpeaking]);
+  }, [
+    lipsyncManager,
+    webrtcLipsyncManager,
+    isAudioPlaying,
+    audioPlayer,
+    audioSourceType,
+    isAgentSpeaking,
+  ]);
 
   /**
    * Optimization: Cache the mapping from viseme name to morph target indices for each mesh.
    * This avoids looking up `skinnedMesh.morphTargetDictionary[target]` in every frame loop.
    */
   const morphTargetCache = useMemo(() => {
-    const cache: Record<string, Array<{ mesh: SkinnedMesh; index: number }>> = {};
+    const cache: Record<
+      string,
+      Array<{ mesh: SkinnedMesh; index: number }>
+    > = {};
 
     VISEME_VALUES.forEach((viseme) => {
       cache[viseme] = [];
       avatarSkinnedMeshes.forEach((mesh) => {
-        if (mesh.morphTargetDictionary && mesh.morphTargetDictionary[viseme] !== undefined) {
+        if (
+          mesh.morphTargetDictionary &&
+          mesh.morphTargetDictionary[viseme] !== undefined
+        ) {
           cache[viseme].push({
             mesh,
             index: mesh.morphTargetDictionary[viseme],
@@ -75,17 +96,20 @@ export const useVisemeManager = ({ avatarSkinnedMeshes }: UseVisemeManagerParams
 
   /**
    * Update a morph target value with smoothing
+   * Returns true if the target is settled (reached target value)
    */
   const updateMorphTarget = useCallback(
-    (target: string, targetValue: number): void => {
+    (target: string, targetValue: number): boolean => {
       const targets = morphTargetCache[target];
-      if (!targets) return;
+      if (!targets) return true;
+
+      let allSettled = true;
 
       for (let i = 0; i < targets.length; i++) {
         const { mesh, index } = targets[i];
         if (
           mesh.morphTargetInfluences &&
-          typeof mesh.morphTargetInfluences[index] === 'number'
+          typeof mesh.morphTargetInfluences[index] === "number"
         ) {
           const currentValue = mesh.morphTargetInfluences[index];
 
@@ -98,17 +122,34 @@ export const useVisemeManager = ({ avatarSkinnedMeshes }: UseVisemeManagerParams
             continue;
           }
 
+          // If we reach here, we are updating, so not settled
+          allSettled = false;
+
           const smoothing =
             targetValue > currentValue
               ? ANIMATION_CONSTANTS.VISEME_ACTIVATION_SMOOTHING
               : ANIMATION_CONSTANTS.VISEME_DEACTIVATION_SMOOTHING;
 
-          mesh.morphTargetInfluences[index] = MathUtils.lerp(currentValue, targetValue, smoothing);
+          mesh.morphTargetInfluences[index] = MathUtils.lerp(
+            currentValue,
+            targetValue,
+            smoothing,
+          );
         }
       }
+
+      return allSettled;
     },
-    [morphTargetCache]
+    [morphTargetCache],
   );
+
+  // Track if visemes are settled to 0 (idle)
+  const visemesSettledRef = useRef(false);
+
+  // Reset settled state when meshes change
+  useEffect(() => {
+    visemesSettledRef.current = false;
+  }, [avatarSkinnedMeshes]);
 
   // Debug logging ref to avoid spamming
   const lastLogTimeRef = useRef(0);
@@ -118,24 +159,27 @@ export const useVisemeManager = ({ avatarSkinnedMeshes }: UseVisemeManagerParams
     const currentSourceType = audioSourceTypeRef.current;
     const currentAudioPlayer = audioPlayerRef.current;
     const currentIsAgentSpeaking = isAgentSpeakingRef.current;
-    
+
     // Get the appropriate lipsync manager based on source type
-    const currentLipsyncManager = currentSourceType === 'webrtc'
-      ? webrtcLipsyncManagerRef.current
-      : lipsyncManagerRef.current;
+    const currentLipsyncManager =
+      currentSourceType === "webrtc"
+        ? webrtcLipsyncManagerRef.current
+        : lipsyncManagerRef.current;
 
     // Check if audio is actually playing
     // For WebRTC, we rely on isAudioPlaying state and the analyzer connection
     // For file audio, we check the audio element state AND if agent is speaking
-    const isPlaying = currentSourceType === 'webrtc'
-      ? currentIsAudioPlaying && currentLipsyncManager
-      : currentAudioPlayer &&
-        !currentAudioPlayer.paused &&
-        !currentAudioPlayer.ended &&
-        currentAudioPlayer.currentTime > 0 &&
-        currentIsAgentSpeaking; // Only lipsync when agent is speaking
+    const isPlaying =
+      currentSourceType === "webrtc"
+        ? currentIsAudioPlaying && currentLipsyncManager
+        : currentAudioPlayer &&
+          !currentAudioPlayer.paused &&
+          !currentAudioPlayer.ended &&
+          currentAudioPlayer.currentTime > 0 &&
+          currentIsAgentSpeaking; // Only lipsync when agent is speaking
 
     if (isPlaying && currentIsAudioPlaying && currentLipsyncManager) {
+      visemesSettledRef.current = false;
       currentLipsyncManager.processAudio();
       const currentViseme = currentLipsyncManager.viseme;
 
@@ -143,10 +187,10 @@ export const useVisemeManager = ({ avatarSkinnedMeshes }: UseVisemeManagerParams
       if (import.meta.env.DEV) {
         const now = Date.now();
         if (now - lastLogTimeRef.current > 1000) {
-          console.log('[useVisemeManager] Processing audio', {
+          console.log("[useVisemeManager] Processing audio", {
             sourceType: currentSourceType,
             viseme: currentViseme,
-            isWebRTC: currentSourceType === 'webrtc',
+            isWebRTC: currentSourceType === "webrtc",
           });
           lastLogTimeRef.current = now;
         }
@@ -157,10 +201,19 @@ export const useVisemeManager = ({ avatarSkinnedMeshes }: UseVisemeManagerParams
         updateMorphTarget(viseme, targetValue);
       });
     } else {
+      // Short-circuit if already settled
+      if (visemesSettledRef.current) return;
+
       // Reset all visemes when not playing
+      let allSettled = true;
       VISEME_VALUES.forEach((viseme) => {
-        updateMorphTarget(viseme, 0);
+        const settled = updateMorphTarget(viseme, 0);
+        if (!settled) allSettled = false;
       });
+
+      if (allSettled) {
+        visemesSettledRef.current = true;
+      }
     }
   });
 };


### PR DESCRIPTION
* 💡 What: Implemented a "settled" state check in `useVisemeManager` to stop the `useFrame` loop from running updates when all visemes are zero (idle). Also refactored `updateMorphTarget` to return a boolean status.
* 🎯 Why: The previous implementation iterated over all visemes and meshes every frame even when the character was not speaking, causing unnecessary CPU usage and potential Three.js overhead.
* 📊 Impact: Reduces unnecessary `morphTargetInfluences` reads and potential writes to zero when idle. Verified by test to stop reads completely when settled.
* 🔬 Measurement: Added `useVisemeManager.test.tsx` which verifies that reads on `morphTargetInfluences` stop after the animation settles.

---
*PR created automatically by Jules for task [14736128324814454768](https://jules.google.com/task/14736128324814454768) started by @santosflores*